### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,9 +36,9 @@ jobs:
           tag: ci-semi-stable
 
       - name: Setup typst
-        uses: yusancky/setup-typst@v2
+        uses: typst-community/setup-typst@v4
         with:
-          version: 'v0.11.0'
+          typst-version: 'v0.11.0'
 
       - name: Run test suite
         run: just ci


### PR DESCRIPTION
Bump [`typst-community/setup-typst`](https://github.com/typst-community/setup-typst) to v4

> [!IMPORTANT] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://github.com/yusancky/setup-typst/blob/main/announcement.md) for more information.